### PR TITLE
Add annotations to JavaBean getters

### DIFF
--- a/src/main/resources/templates/java-lang/type.ftl
+++ b/src/main/resources/templates/java-lang/type.ftl
@@ -73,6 +73,9 @@ public class ${className} implements java.io.Serializable<#if implements?has_con
         <#if field.deprecated?has_content>
     @${field.deprecated.annotation}
         </#if>
+        <#list field.annotations as annotation>
+    @${annotation}
+        </#list>
     public <#if field.mandatory && field.definitionInParentType?has_content && !field.definitionInParentType.mandatory>${field.definitionInParentType.type}<#else>${field.type}</#if> get${field.name?cap_first}() {
         return ${field.name};
     }

--- a/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenDefaultsTest.java
+++ b/src/test/java/com/kobylynskyi/graphql/codegen/GraphQLCodegenDefaultsTest.java
@@ -54,7 +54,7 @@ class GraphQLCodegenDefaultsTest {
     }
 
     @Test
-    void generate_UnkonwnFields() throws Exception {
+    void generate_UnknownFields() throws Exception {
         mappingConfig.setSupportUnknownFields(true);
         mappingConfig.setUnknownFieldsPropertyName("userDefinedFields");
 

--- a/src/test/resources/expected-classes/CommentDeletedEvent.java.txt
+++ b/src/test/resources/expected-classes/CommentDeletedEvent.java.txt
@@ -19,6 +19,7 @@ public class CommentDeletedEvent implements java.io.Serializable, IssueTimelineI
         this.id = id;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }

--- a/src/test/resources/expected-classes/Commit.java.txt
+++ b/src/test/resources/expected-classes/Commit.java.txt
@@ -116,6 +116,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.zipballUrl = zipballUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public String getAbbreviatedOid() {
         return abbreviatedOid;
     }
@@ -151,6 +152,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.authoredByCommitter = authoredByCommitter;
     }
 
+    @javax.validation.constraints.NotNull
     public String getAuthoredDate() {
         return authoredDate;
     }
@@ -158,6 +160,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.authoredDate = authoredDate;
     }
 
+    @javax.validation.constraints.NotNull
     public Blame getBlame() {
         return blame;
     }
@@ -172,6 +175,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.changedFiles = changedFiles;
     }
 
+    @javax.validation.constraints.NotNull
     public CommitCommentConnection getComments() {
         return comments;
     }
@@ -179,6 +183,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.comments = comments;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCommitResourcePath() {
         return commitResourcePath;
     }
@@ -186,6 +191,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.commitResourcePath = commitResourcePath;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCommitUrl() {
         return commitUrl;
     }
@@ -193,6 +199,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.commitUrl = commitUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCommittedDate() {
         return committedDate;
     }
@@ -228,6 +235,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.deployments = deployments;
     }
 
+    @javax.validation.constraints.NotNull
     public CommitHistoryConnection getHistory() {
         return history;
     }
@@ -235,6 +243,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.history = history;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }
@@ -242,6 +251,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.id = id;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessage() {
         return message;
     }
@@ -249,6 +259,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.message = message;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageBody() {
         return messageBody;
     }
@@ -256,6 +267,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.messageBody = messageBody;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageBodyHTML() {
         return messageBodyHTML;
     }
@@ -263,6 +275,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.messageBodyHTML = messageBodyHTML;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageHeadline() {
         return messageHeadline;
     }
@@ -270,6 +283,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.messageHeadline = messageHeadline;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageHeadlineHTML() {
         return messageHeadlineHTML;
     }
@@ -277,6 +291,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.messageHeadlineHTML = messageHeadlineHTML;
     }
 
+    @javax.validation.constraints.NotNull
     public String getOid() {
         return oid;
     }
@@ -284,6 +299,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.oid = oid;
     }
 
+    @javax.validation.constraints.NotNull
     public CommitConnection getParents() {
         return parents;
     }
@@ -298,6 +314,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.pushedDate = pushedDate;
     }
 
+    @javax.validation.constraints.NotNull
     public Repository getRepository() {
         return repository;
     }
@@ -305,6 +322,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.repository = repository;
     }
 
+    @javax.validation.constraints.NotNull
     public String getResourcePath() {
         return resourcePath;
     }
@@ -326,6 +344,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.status = status;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTarballUrl() {
         return tarballUrl;
     }
@@ -333,6 +352,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.tarballUrl = tarballUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public Tree getTree() {
         return tree;
     }
@@ -340,6 +360,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.tree = tree;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTreeResourcePath() {
         return treeResourcePath;
     }
@@ -347,6 +368,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.treeResourcePath = treeResourcePath;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTreeUrl() {
         return treeUrl;
     }
@@ -354,6 +376,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.treeUrl = treeUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public String getUrl() {
         return url;
     }
@@ -375,6 +398,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.viewerSubscription = viewerSubscription;
     }
 
+    @javax.validation.constraints.NotNull
     public String getZipballUrl() {
         return zipballUrl;
     }

--- a/src/test/resources/expected-classes/Commit_noParametrizedFields.java.txt
+++ b/src/test/resources/expected-classes/Commit_noParametrizedFields.java.txt
@@ -100,6 +100,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.zipballUrl = zipballUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public String getAbbreviatedOid() {
         return abbreviatedOid;
     }
@@ -128,6 +129,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.authoredByCommitter = authoredByCommitter;
     }
 
+    @javax.validation.constraints.NotNull
     public String getAuthoredDate() {
         return authoredDate;
     }
@@ -142,6 +144,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.changedFiles = changedFiles;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCommitResourcePath() {
         return commitResourcePath;
     }
@@ -149,6 +152,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.commitResourcePath = commitResourcePath;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCommitUrl() {
         return commitUrl;
     }
@@ -156,6 +160,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.commitUrl = commitUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCommittedDate() {
         return committedDate;
     }
@@ -184,6 +189,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.deletions = deletions;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }
@@ -191,6 +197,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.id = id;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessage() {
         return message;
     }
@@ -198,6 +205,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.message = message;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageBody() {
         return messageBody;
     }
@@ -205,6 +213,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.messageBody = messageBody;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageBodyHTML() {
         return messageBodyHTML;
     }
@@ -212,6 +221,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.messageBodyHTML = messageBodyHTML;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageHeadline() {
         return messageHeadline;
     }
@@ -219,6 +229,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.messageHeadline = messageHeadline;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageHeadlineHTML() {
         return messageHeadlineHTML;
     }
@@ -226,6 +237,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.messageHeadlineHTML = messageHeadlineHTML;
     }
 
+    @javax.validation.constraints.NotNull
     public String getOid() {
         return oid;
     }
@@ -240,6 +252,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.pushedDate = pushedDate;
     }
 
+    @javax.validation.constraints.NotNull
     public Repository getRepository() {
         return repository;
     }
@@ -247,6 +260,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.repository = repository;
     }
 
+    @javax.validation.constraints.NotNull
     public String getResourcePath() {
         return resourcePath;
     }
@@ -268,6 +282,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.status = status;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTarballUrl() {
         return tarballUrl;
     }
@@ -275,6 +290,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.tarballUrl = tarballUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public Tree getTree() {
         return tree;
     }
@@ -282,6 +298,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.tree = tree;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTreeResourcePath() {
         return treeResourcePath;
     }
@@ -289,6 +306,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.treeResourcePath = treeResourcePath;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTreeUrl() {
         return treeUrl;
     }
@@ -296,6 +314,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.treeUrl = treeUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public String getUrl() {
         return url;
     }
@@ -317,6 +336,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.viewerSubscription = viewerSubscription;
     }
 
+    @javax.validation.constraints.NotNull
     public String getZipballUrl() {
         return zipballUrl;
     }

--- a/src/test/resources/expected-classes/Commit_withoutPrimitives.java.txt
+++ b/src/test/resources/expected-classes/Commit_withoutPrimitives.java.txt
@@ -122,6 +122,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.zipballUrl = zipballUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public String getAbbreviatedOid() {
         return abbreviatedOid;
     }
@@ -129,6 +130,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.abbreviatedOid = abbreviatedOid;
     }
 
+    @javax.validation.constraints.NotNull
     public Integer getAdditions() {
         return additions;
     }
@@ -150,6 +152,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.author = author;
     }
 
+    @javax.validation.constraints.NotNull
     public Boolean getAuthoredByCommitter() {
         return authoredByCommitter;
     }
@@ -157,6 +160,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.authoredByCommitter = authoredByCommitter;
     }
 
+    @javax.validation.constraints.NotNull
     public String getAuthoredDate() {
         return authoredDate;
     }
@@ -164,6 +168,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.authoredDate = authoredDate;
     }
 
+    @javax.validation.constraints.NotNull
     public Blame getBlame() {
         return blame;
     }
@@ -171,6 +176,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.blame = blame;
     }
 
+    @javax.validation.constraints.NotNull
     public Integer getChangedFiles() {
         return changedFiles;
     }
@@ -178,6 +184,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.changedFiles = changedFiles;
     }
 
+    @javax.validation.constraints.NotNull
     public CommitCommentConnection getComments() {
         return comments;
     }
@@ -185,6 +192,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.comments = comments;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCommitResourcePath() {
         return commitResourcePath;
     }
@@ -192,6 +200,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.commitResourcePath = commitResourcePath;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCommitUrl() {
         return commitUrl;
     }
@@ -199,6 +208,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.commitUrl = commitUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCommittedDate() {
         return committedDate;
     }
@@ -206,6 +216,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.committedDate = committedDate;
     }
 
+    @javax.validation.constraints.NotNull
     public Boolean getCommittedViaWeb() {
         return committedViaWeb;
     }
@@ -220,6 +231,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.committer = committer;
     }
 
+    @javax.validation.constraints.NotNull
     public Integer getDeletions() {
         return deletions;
     }
@@ -234,6 +246,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.deployments = deployments;
     }
 
+    @javax.validation.constraints.NotNull
     public CommitHistoryConnection getHistory() {
         return history;
     }
@@ -241,6 +254,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.history = history;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }
@@ -248,6 +262,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.id = id;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessage() {
         return message;
     }
@@ -255,6 +270,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.message = message;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageBody() {
         return messageBody;
     }
@@ -262,6 +278,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.messageBody = messageBody;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageBodyHTML() {
         return messageBodyHTML;
     }
@@ -269,6 +286,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.messageBodyHTML = messageBodyHTML;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageHeadline() {
         return messageHeadline;
     }
@@ -276,6 +294,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.messageHeadline = messageHeadline;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageHeadlineHTML() {
         return messageHeadlineHTML;
     }
@@ -283,6 +302,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.messageHeadlineHTML = messageHeadlineHTML;
     }
 
+    @javax.validation.constraints.NotNull
     public String getOid() {
         return oid;
     }
@@ -290,6 +310,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.oid = oid;
     }
 
+    @javax.validation.constraints.NotNull
     public CommitConnection getParents() {
         return parents;
     }
@@ -304,6 +325,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.pushedDate = pushedDate;
     }
 
+    @javax.validation.constraints.NotNull
     public Repository getRepository() {
         return repository;
     }
@@ -311,6 +333,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.repository = repository;
     }
 
+    @javax.validation.constraints.NotNull
     public String getResourcePath() {
         return resourcePath;
     }
@@ -332,6 +355,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.status = status;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTarballUrl() {
         return tarballUrl;
     }
@@ -339,6 +363,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.tarballUrl = tarballUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public Tree getTree() {
         return tree;
     }
@@ -346,6 +371,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.tree = tree;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTreeResourcePath() {
         return treeResourcePath;
     }
@@ -353,6 +379,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.treeResourcePath = treeResourcePath;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTreeUrl() {
         return treeUrl;
     }
@@ -360,6 +387,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.treeUrl = treeUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public String getUrl() {
         return url;
     }
@@ -367,6 +395,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.url = url;
     }
 
+    @javax.validation.constraints.NotNull
     public Boolean getViewerCanSubscribe() {
         return viewerCanSubscribe;
     }
@@ -381,6 +410,7 @@ public class Commit implements java.io.Serializable, Closer, IssueTimelineItem, 
         this.viewerSubscription = viewerSubscription;
     }
 
+    @javax.validation.constraints.NotNull
     public String getZipballUrl() {
         return zipballUrl;
     }

--- a/src/test/resources/expected-classes/GithubAcceptTopicSuggestionInputTO.java.txt
+++ b/src/test/resources/expected-classes/GithubAcceptTopicSuggestionInputTO.java.txt
@@ -31,6 +31,7 @@ public class GithubAcceptTopicSuggestionInputTO implements java.io.Serializable 
         this.clientMutationId = clientMutationId;
     }
 
+    @javax.validation.constraints.NotNull
     public String getName() {
         return name;
     }
@@ -38,6 +39,7 @@ public class GithubAcceptTopicSuggestionInputTO implements java.io.Serializable 
         this.name = name;
     }
 
+    @javax.validation.constraints.NotNull
     public String getRepositoryId() {
         return repositoryId;
     }

--- a/src/test/resources/expected-classes/GithubCommitTO.java.txt
+++ b/src/test/resources/expected-classes/GithubCommitTO.java.txt
@@ -116,6 +116,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.zipballUrl = zipballUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public String getAbbreviatedOid() {
         return abbreviatedOid;
     }
@@ -151,6 +152,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.authoredByCommitter = authoredByCommitter;
     }
 
+    @javax.validation.constraints.NotNull
     public String getAuthoredDate() {
         return authoredDate;
     }
@@ -158,6 +160,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.authoredDate = authoredDate;
     }
 
+    @javax.validation.constraints.NotNull
     public GithubBlameTO getBlame() {
         return blame;
     }
@@ -172,6 +175,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.changedFiles = changedFiles;
     }
 
+    @javax.validation.constraints.NotNull
     public GithubCommitCommentConnectionTO getComments() {
         return comments;
     }
@@ -179,6 +183,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.comments = comments;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCommitResourcePath() {
         return commitResourcePath;
     }
@@ -186,6 +191,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.commitResourcePath = commitResourcePath;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCommitUrl() {
         return commitUrl;
     }
@@ -193,6 +199,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.commitUrl = commitUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCommittedDate() {
         return committedDate;
     }
@@ -228,6 +235,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.deployments = deployments;
     }
 
+    @javax.validation.constraints.NotNull
     public GithubCommitHistoryConnectionTO getHistory() {
         return history;
     }
@@ -235,6 +243,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.history = history;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }
@@ -242,6 +251,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.id = id;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessage() {
         return message;
     }
@@ -249,6 +259,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.message = message;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageBody() {
         return messageBody;
     }
@@ -256,6 +267,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.messageBody = messageBody;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageBodyHTML() {
         return messageBodyHTML;
     }
@@ -263,6 +275,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.messageBodyHTML = messageBodyHTML;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageHeadline() {
         return messageHeadline;
     }
@@ -270,6 +283,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.messageHeadline = messageHeadline;
     }
 
+    @javax.validation.constraints.NotNull
     public String getMessageHeadlineHTML() {
         return messageHeadlineHTML;
     }
@@ -277,6 +291,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.messageHeadlineHTML = messageHeadlineHTML;
     }
 
+    @javax.validation.constraints.NotNull
     public String getOid() {
         return oid;
     }
@@ -284,6 +299,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.oid = oid;
     }
 
+    @javax.validation.constraints.NotNull
     public GithubCommitConnectionTO getParents() {
         return parents;
     }
@@ -298,6 +314,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.pushedDate = pushedDate;
     }
 
+    @javax.validation.constraints.NotNull
     public GithubRepositoryTO getRepository() {
         return repository;
     }
@@ -305,6 +322,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.repository = repository;
     }
 
+    @javax.validation.constraints.NotNull
     public String getResourcePath() {
         return resourcePath;
     }
@@ -326,6 +344,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.status = status;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTarballUrl() {
         return tarballUrl;
     }
@@ -333,6 +352,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.tarballUrl = tarballUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public GithubTreeTO getTree() {
         return tree;
     }
@@ -340,6 +360,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.tree = tree;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTreeResourcePath() {
         return treeResourcePath;
     }
@@ -347,6 +368,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.treeResourcePath = treeResourcePath;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTreeUrl() {
         return treeUrl;
     }
@@ -354,6 +376,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.treeUrl = treeUrl;
     }
 
+    @javax.validation.constraints.NotNull
     public String getUrl() {
         return url;
     }
@@ -375,6 +398,7 @@ public class GithubCommitTO implements java.io.Serializable, GithubCloserTO, Git
         this.viewerSubscription = viewerSubscription;
     }
 
+    @javax.validation.constraints.NotNull
     public String getZipballUrl() {
         return zipballUrl;
     }

--- a/src/test/resources/expected-classes/annotation/User.java.txt
+++ b/src/test/resources/expected-classes/annotation/User.java.txt
@@ -31,6 +31,7 @@ public class User implements java.io.Serializable {
         this.name = name;
     }
 
+    @com.example.Relationship(type = "FRIEND_WITH", direction = OUT)
     public java.util.List<User> getFriends() {
         return friends;
     }

--- a/src/test/resources/expected-classes/defaults/InputWithDefaults.java.txt
+++ b/src/test/resources/expected-classes/defaults/InputWithDefaults.java.txt
@@ -78,6 +78,7 @@ public class InputWithDefaults implements java.io.Serializable {
         this.enumVal = enumVal;
     }
 
+    @javax.validation.constraints.NotNull
     public MyEnum getNonNullEnumVal() {
         return nonNullEnumVal;
     }
@@ -113,6 +114,7 @@ public class InputWithDefaults implements java.io.Serializable {
         this.intListEmptyDefault = intListEmptyDefault;
     }
 
+    @javax.validation.constraints.NotNull
     public java.util.List<SomeObject> getObjectListEmptyDefault() {
         return objectListEmptyDefault;
     }

--- a/src/test/resources/expected-classes/defaults/InputWithDefaultsDTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/InputWithDefaultsDTO.java.txt
@@ -80,6 +80,7 @@ public class InputWithDefaultsDTO implements java.io.Serializable {
         this.enumVal = enumVal;
     }
 
+    @javax.validation.constraints.NotNull
     public MyEnumDTO getNonNullEnumVal() {
         return nonNullEnumVal;
     }
@@ -115,6 +116,7 @@ public class InputWithDefaultsDTO implements java.io.Serializable {
         this.intListEmptyDefault = intListEmptyDefault;
     }
 
+    @javax.validation.constraints.NotNull
     public java.util.List<SomeObjectDTO> getObjectListEmptyDefault() {
         return objectListEmptyDefault;
     }

--- a/src/test/resources/expected-classes/defaults/InputWithDefaultsTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/InputWithDefaultsTO.java.txt
@@ -78,6 +78,7 @@ public class InputWithDefaultsTO implements java.io.Serializable {
         this.enumVal = enumVal;
     }
 
+    @javax.validation.constraints.NotNull
     public MyEnumTO getNonNullEnumVal() {
         return nonNullEnumVal;
     }
@@ -113,6 +114,7 @@ public class InputWithDefaultsTO implements java.io.Serializable {
         this.intListEmptyDefault = intListEmptyDefault;
     }
 
+    @javax.validation.constraints.NotNull
     public java.util.List<SomeObjectTO> getObjectListEmptyDefault() {
         return objectListEmptyDefault;
     }

--- a/src/test/resources/expected-classes/defaults/SomeObject.java.txt
+++ b/src/test/resources/expected-classes/defaults/SomeObject.java.txt
@@ -19,6 +19,7 @@ public class SomeObject implements java.io.Serializable {
         this.name = name;
     }
 
+    @javax.validation.constraints.NotNull
     public String getName() {
         return name;
     }

--- a/src/test/resources/expected-classes/defaults/SomeObjectDTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/SomeObjectDTO.java.txt
@@ -19,6 +19,7 @@ public class SomeObjectDTO implements java.io.Serializable {
         this.name = name;
     }
 
+    @javax.validation.constraints.NotNull
     public String getName() {
         return name;
     }

--- a/src/test/resources/expected-classes/defaults/SomeObjectTO.java.txt
+++ b/src/test/resources/expected-classes/defaults/SomeObjectTO.java.txt
@@ -19,6 +19,7 @@ public class SomeObjectTO implements java.io.Serializable {
         this.name = name;
     }
 
+    @javax.validation.constraints.NotNull
     public String getName() {
         return name;
     }

--- a/src/test/resources/expected-classes/deprecated/Event.java.txt
+++ b/src/test/resources/expected-classes/deprecated/Event.java.txt
@@ -29,6 +29,7 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
     }
 
     @Deprecated
+    @javax.validation.constraints.NotNull
     public Status getStatus() {
         return status;
     }
@@ -38,6 +39,7 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
     }
 
     @Deprecated
+    @javax.validation.constraints.NotNull
     public String getCreatedDateTime() {
         return createdDateTime;
     }
@@ -47,6 +49,7 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
     }
 
     @Deprecated
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }

--- a/src/test/resources/expected-classes/deprecated/EventInput.java.txt
+++ b/src/test/resources/expected-classes/deprecated/EventInput.java.txt
@@ -21,6 +21,7 @@ public class EventInput implements java.io.Serializable {
     }
 
     @Deprecated
+    @javax.validation.constraints.NotNull
     public Status getStatus() {
         return status;
     }

--- a/src/test/resources/expected-classes/extend-with-resolvers/Asset.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/Asset.java.txt
@@ -22,6 +22,7 @@ public class Asset implements java.io.Serializable, PinnableItem, Node {
         this.id = id;
     }
 
+    @javax.validation.constraints.NotNull
     public String getName() {
         return name;
     }
@@ -29,6 +30,7 @@ public class Asset implements java.io.Serializable, PinnableItem, Node {
         this.name = name;
     }
 
+    @javax.validation.constraints.NotNull
     public Status getStatus() {
         return status;
     }
@@ -36,6 +38,7 @@ public class Asset implements java.io.Serializable, PinnableItem, Node {
         this.status = status;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }

--- a/src/test/resources/expected-classes/extend-with-resolvers/AssetInput.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/AssetInput.java.txt
@@ -16,6 +16,7 @@ public class AssetInput implements java.io.Serializable {
         this.name = name;
     }
 
+    @javax.validation.constraints.NotNull
     public String getName() {
         return name;
     }

--- a/src/test/resources/expected-classes/extend-with-resolvers/Event.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/Event.java.txt
@@ -22,6 +22,7 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
         this.id = id;
     }
 
+    @javax.validation.constraints.NotNull
     public Status getStatus() {
         return status;
     }
@@ -29,6 +30,7 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
         this.status = status;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCreatedDateTime() {
         return createdDateTime;
     }
@@ -36,6 +38,7 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
         this.createdDateTime = createdDateTime;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }

--- a/src/test/resources/expected-classes/extend-with-resolvers/EventInput.java.txt
+++ b/src/test/resources/expected-classes/extend-with-resolvers/EventInput.java.txt
@@ -19,6 +19,7 @@ public class EventInput implements java.io.Serializable {
         this.assets = assets;
     }
 
+    @javax.validation.constraints.NotNull
     public Status getStatus() {
         return status;
     }
@@ -26,6 +27,7 @@ public class EventInput implements java.io.Serializable {
         this.status = status;
     }
 
+    @javax.validation.constraints.NotNull
     public java.util.List<AssetInput> getAssets() {
         return assets;
     }

--- a/src/test/resources/expected-classes/extend/Asset.java.txt
+++ b/src/test/resources/expected-classes/extend/Asset.java.txt
@@ -24,6 +24,7 @@ public class Asset implements java.io.Serializable, PinnableItem, Node {
         this.createdBy = createdBy;
     }
 
+    @javax.validation.constraints.NotNull
     public String getName() {
         return name;
     }
@@ -31,6 +32,7 @@ public class Asset implements java.io.Serializable, PinnableItem, Node {
         this.name = name;
     }
 
+    @javax.validation.constraints.NotNull
     public Status getStatus() {
         return status;
     }
@@ -38,6 +40,7 @@ public class Asset implements java.io.Serializable, PinnableItem, Node {
         this.status = status;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }

--- a/src/test/resources/expected-classes/extend/AssetInput.java.txt
+++ b/src/test/resources/expected-classes/extend/AssetInput.java.txt
@@ -16,6 +16,7 @@ public class AssetInput implements java.io.Serializable {
         this.name = name;
     }
 
+    @javax.validation.constraints.NotNull
     public String getName() {
         return name;
     }

--- a/src/test/resources/expected-classes/extend/Event.java.txt
+++ b/src/test/resources/expected-classes/extend/Event.java.txt
@@ -27,6 +27,7 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
         this.createdBy = createdBy;
     }
 
+    @javax.validation.constraints.NotNull
     public Status getStatus() {
         return status;
     }
@@ -34,6 +35,7 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
         this.status = status;
     }
 
+    @javax.validation.constraints.NotNull
     public String getCreatedDateTime() {
         return createdDateTime;
     }
@@ -44,6 +46,7 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
     /**
      * Optional list of assets
      */
+    @javax.validation.constraints.NotNull
     public java.util.List<Asset> getAssets() {
         return assets;
     }
@@ -54,6 +57,7 @@ public class Event implements java.io.Serializable, PinnableItem, Node {
         this.assets = assets;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }

--- a/src/test/resources/expected-classes/extend/EventInput.java.txt
+++ b/src/test/resources/expected-classes/extend/EventInput.java.txt
@@ -19,6 +19,7 @@ public class EventInput implements java.io.Serializable {
         this.assets = assets;
     }
 
+    @javax.validation.constraints.NotNull
     public Status getStatus() {
         return status;
     }
@@ -26,6 +27,7 @@ public class EventInput implements java.io.Serializable {
         this.status = status;
     }
 
+    @javax.validation.constraints.NotNull
     public java.util.List<AssetInput> getAssets() {
         return assets;
     }

--- a/src/test/resources/expected-classes/from-introspection-result/Product.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/Product.java.txt
@@ -37,6 +37,7 @@ public class Product implements java.io.Serializable {
         this.addedDateTime = addedDateTime;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }
@@ -44,6 +45,7 @@ public class Product implements java.io.Serializable {
         this.id = id;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTitle() {
         return title;
     }
@@ -58,6 +60,7 @@ public class Product implements java.io.Serializable {
         this.description = description;
     }
 
+    @javax.validation.constraints.NotNull
     public String getPrice() {
         return price;
     }
@@ -65,6 +68,7 @@ public class Product implements java.io.Serializable {
         this.price = price;
     }
 
+    @javax.validation.constraints.NotNull
     public String getSku() {
         return sku;
     }
@@ -79,6 +83,7 @@ public class Product implements java.io.Serializable {
         this.stockStatus = stockStatus;
     }
 
+    @javax.validation.constraints.NotNull
     public String getAddedDateTime() {
         return addedDateTime;
     }

--- a/src/test/resources/expected-classes/from-introspection-result/ProductInput.java.txt
+++ b/src/test/resources/expected-classes/from-introspection-result/ProductInput.java.txt
@@ -31,6 +31,7 @@ public class ProductInput implements java.io.Serializable {
         this.stockStatus = stockStatus;
     }
 
+    @javax.validation.constraints.NotNull
     public String getTitle() {
         return title;
     }
@@ -45,6 +46,7 @@ public class ProductInput implements java.io.Serializable {
         this.description = description;
     }
 
+    @javax.validation.constraints.NotNull
     public String getPrice() {
         return price;
     }
@@ -52,6 +54,7 @@ public class ProductInput implements java.io.Serializable {
         this.price = price;
     }
 
+    @javax.validation.constraints.NotNull
     public String getSku() {
         return sku;
     }

--- a/src/test/resources/expected-classes/interfaces/Bar1.java.txt
+++ b/src/test/resources/expected-classes/interfaces/Bar1.java.txt
@@ -19,6 +19,7 @@ public class Bar1 implements java.io.Serializable, Bar {
         this.id = id;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }

--- a/src/test/resources/expected-classes/interfaces/Foo1.java.txt
+++ b/src/test/resources/expected-classes/interfaces/Foo1.java.txt
@@ -21,6 +21,7 @@ public class Foo1 implements java.io.Serializable, Foo {
         this.bars = bars;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }

--- a/src/test/resources/expected-classes/relay/Organization.java.txt
+++ b/src/test/resources/expected-classes/relay/Organization.java.txt
@@ -17,6 +17,7 @@ public class Organization implements java.io.Serializable {
         this.id = id;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }

--- a/src/test/resources/expected-classes/relay/User.java.txt
+++ b/src/test/resources/expected-classes/relay/User.java.txt
@@ -19,6 +19,7 @@ public class User implements java.io.Serializable {
         this.name = name;
     }
 
+    @javax.validation.constraints.NotNull
     public String getId() {
         return id;
     }

--- a/src/test/resources/expected-classes/request/AcceptTopicSuggestionInput.java.txt
+++ b/src/test/resources/expected-classes/request/AcceptTopicSuggestionInput.java.txt
@@ -34,6 +34,7 @@ public class AcceptTopicSuggestionInput implements java.io.Serializable {
         this.clientMutationId = clientMutationId;
     }
 
+    @javax.validation.constraints.NotNull
     public String getName() {
         return name;
     }
@@ -41,6 +42,7 @@ public class AcceptTopicSuggestionInput implements java.io.Serializable {
         this.name = name;
     }
 
+    @javax.validation.constraints.NotNull
     public String getRepositoryId() {
         return repositoryId;
     }

--- a/src/test/resources/expected-classes/types-as-interfaces-extends-interface/Profile.java.txt
+++ b/src/test/resources/expected-classes/types-as-interfaces-extends-interface/Profile.java.txt
@@ -22,6 +22,7 @@ public class Profile implements java.io.Serializable {
         this.lastName = lastName;
     }
 
+    @javax.validation.constraints.NotNull
     public String getFirstName() {
         return firstName;
     }
@@ -29,6 +30,7 @@ public class Profile implements java.io.Serializable {
         this.firstName = firstName;
     }
 
+    @javax.validation.constraints.NotNull
     public String getLastName() {
         return lastName;
     }

--- a/src/test/resources/expected-classes/unknown-fields/InputWithDefaults.java.txt
+++ b/src/test/resources/expected-classes/unknown-fields/InputWithDefaults.java.txt
@@ -82,6 +82,7 @@ public class InputWithDefaults implements java.io.Serializable {
         this.enumVal = enumVal;
     }
 
+    @javax.validation.constraints.NotNull
     public MyEnum getNonNullEnumVal() {
         return nonNullEnumVal;
     }
@@ -117,6 +118,7 @@ public class InputWithDefaults implements java.io.Serializable {
         this.intListEmptyDefault = intListEmptyDefault;
     }
 
+    @javax.validation.constraints.NotNull
     public java.util.List<SomeObject> getObjectListEmptyDefault() {
         return objectListEmptyDefault;
     }
@@ -124,6 +126,8 @@ public class InputWithDefaults implements java.io.Serializable {
         this.objectListEmptyDefault = objectListEmptyDefault;
     }
 
+    @com.fasterxml.jackson.annotation.JsonAnyGetter
+    @com.fasterxml.jackson.annotation.JsonAnySetter
     public java.util.Map<String, Object> getUserDefinedFields() {
         return userDefinedFields;
     }

--- a/src/test/resources/expected-classes/unknown-fields/SomeObject.java.txt
+++ b/src/test/resources/expected-classes/unknown-fields/SomeObject.java.txt
@@ -23,6 +23,7 @@ public class SomeObject implements java.io.Serializable {
         this.userDefinedFields = userDefinedFields;
     }
 
+    @javax.validation.constraints.NotNull
     public String getName() {
         return name;
     }
@@ -30,6 +31,8 @@ public class SomeObject implements java.io.Serializable {
         this.name = name;
     }
 
+    @com.fasterxml.jackson.annotation.JsonAnyGetter
+    @com.fasterxml.jackson.annotation.JsonAnySetter
     public java.util.Map<String, Object> getUserDefinedFields() {
         return userDefinedFields;
     }


### PR DESCRIPTION

### Description

Add nonnull and other annotations to the getter method in addition to the field declaration. Some Java Bean introspection tools can only use annotations declared on the getter/setter methods, not on the private fields, so we need to repeat the annotation that was placed on the field on the getter as well to get full introspection with annotations.

---

Changes were made to:
- [x] Codegen library - Java
- [ ] Codegen library - Kotlin
- [ ] Codegen library - Scala
- [ ] Maven plugin
- [ ] Gradle plugin
- [ ] SBT plugin
